### PR TITLE
[feat][booking-service] 좌석 도메인 서비스 SeatManager 구현

### DIFF
--- a/src/main/java/com/firstticket/bookingservice/seat/domain/Seat.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/Seat.java
@@ -72,6 +72,9 @@ public class Seat extends BaseEntity {
     }
 
     public void reserve() {
+        if (this.status == SeatStatus.RESERVED) {
+            throw new SeatException(SeatErrorCode.SEAT_ALREADY_RESERVED);
+        }
         this.status = SeatStatus.RESERVED;
     }
 

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/Seat.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/Seat.java
@@ -71,16 +71,7 @@ public class Seat extends BaseEntity {
         );
     }
 
-    public void hold(UUID userId, String sessionId) {
-        // TODO: Redis 좌석 선점 등록
-    }
-
-    public void release() {
-        // TODO: Redis 좌석 선점 해제
-    }
-
     public void reserve() {
-        // TODO: Redis 좌석 선점 해제
         this.status = SeatStatus.RESERVED;
     }
 

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
@@ -16,7 +16,8 @@ public enum SeatErrorCode implements ErrorCode {
     SEAT_ALREADY_HELD(HttpStatus.CONFLICT, "이미 선택된 좌석입니다."),
     SEAT_HOLD_FAILED(HttpStatus.CONFLICT, "이미 선택된 좌석입니다."),
     SEAT_NOT_AVAILABLE(HttpStatus.CONFLICT, "이미 예매된 좌석입니다."),
-    SEAT_NOT_HELD(HttpStatus.CONFLICT, "선점 정보가 유효하지 않습니다.");
+    SEAT_NOT_HELD(HttpStatus.CONFLICT, "선점 정보가 유효하지 않습니다."),
+    SEAT_ALREADY_RESERVED(HttpStatus.CONFLICT, "이미 예매된 좌석입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
@@ -15,7 +15,8 @@ public enum SeatErrorCode implements ErrorCode {
     INVALID_SEAT_PRICE(HttpStatus.BAD_REQUEST, "유효하지 않은 좌석 가격입니다."),
     SEAT_ALREADY_HELD(HttpStatus.CONFLICT, "이미 선택된 좌석입니다."),
     SEAT_HOLD_FAILED(HttpStatus.CONFLICT, "이미 선택된 좌석입니다."),
-    SEAT_NOT_AVAILABLE(HttpStatus.CONFLICT, "이미 예매된 좌석입니다.");
+    SEAT_NOT_AVAILABLE(HttpStatus.CONFLICT, "이미 예매된 좌석입니다."),
+    SEAT_NOT_HELD(HttpStatus.CONFLICT, "선점 정보가 유효하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
@@ -14,7 +14,8 @@ public enum SeatErrorCode implements ErrorCode {
     INVALID_SEAT(HttpStatus.BAD_REQUEST, "유효하지 않은 좌석입니다."),
     INVALID_SEAT_PRICE(HttpStatus.BAD_REQUEST, "유효하지 않은 좌석 가격입니다."),
     SEAT_ALREADY_HELD(HttpStatus.CONFLICT, "이미 선택된 좌석입니다."),
-    SEAT_HOLD_FAILED(HttpStatus.CONFLICT, "이미 선택된 좌석입니다.");
+    SEAT_HOLD_FAILED(HttpStatus.CONFLICT, "이미 선택된 좌석입니다."),
+    SEAT_NOT_AVAILABLE(HttpStatus.CONFLICT, "이미 예매된 좌석입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/service/SeatHoldService.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/service/SeatHoldService.java
@@ -1,0 +1,43 @@
+package com.firstticket.bookingservice.seat.domain.service;
+
+import com.firstticket.bookingservice.seat.domain.Seat;
+import com.firstticket.bookingservice.seat.domain.SeatId;
+import com.firstticket.bookingservice.seat.domain.exception.SeatErrorCode;
+import com.firstticket.bookingservice.seat.domain.exception.SeatException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SeatHoldService {
+
+    private final SeatHoldManager seatHoldManager;
+
+    public void holdSeats(List<Seat> seats, UUID scheduleId, UUID userId, String sessionId) {
+        for (Seat seat : seats) {
+            if (!seat.isAvailable()) {
+                throw new SeatException(SeatErrorCode.SEAT_NOT_AVAILABLE);
+            }
+        }
+
+        List<SeatId> seatIds = seats.stream().map(Seat::getId).toList();
+
+        seatHoldManager.hold(seatIds, scheduleId, userId, sessionId);
+    }
+
+    public boolean releaseSeats(List<SeatId> seatIds, UUID scheduleId, UUID userId, String sessionId) {
+        return seatHoldManager.releaseAll(seatIds, scheduleId, userId, sessionId);
+    }
+
+    public boolean validateHold(List<SeatId> seatIds, UUID userId, String sessionId) {
+        return seatHoldManager.isHeld(seatIds, userId, sessionId);
+    }
+
+    public List<SeatId> getHeldSeats(String sessionId) {
+        return seatHoldManager.getHeldSeatIds(sessionId);
+    }
+
+}

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/service/SeatManager.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/service/SeatManager.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class SeatHoldService {
+public class SeatManager {
 
     private final SeatHoldManager seatHoldManager;
 
@@ -26,6 +26,14 @@ public class SeatHoldService {
         List<SeatId> seatIds = seats.stream().map(Seat::getId).toList();
 
         seatHoldManager.hold(seatIds, scheduleId, userId, sessionId);
+    }
+
+    public void reserveSeats(List<Seat> seats, UUID scheduleId, UUID userId, String sessionId) {
+        if (!validateHold(seats.stream().map(Seat::getId).toList(), userId, sessionId)) {
+            throw new SeatException(SeatErrorCode.SEAT_NOT_HELD);
+        }
+        seats.forEach(Seat::reserve);
+        releaseSeats(seats.stream().map(Seat::getId).toList(), scheduleId, userId, sessionId);
     }
 
     public boolean releaseSeats(List<SeatId> seatIds, UUID scheduleId, UUID userId, String sessionId) {

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/service/SeatManager.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/service/SeatManager.java
@@ -5,12 +5,12 @@ import com.firstticket.bookingservice.seat.domain.SeatId;
 import com.firstticket.bookingservice.seat.domain.exception.SeatErrorCode;
 import com.firstticket.bookingservice.seat.domain.exception.SeatException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.UUID;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class SeatManager {
 

--- a/src/test/java/com/firstticket/bookingservice/seat/domain/service/SeatManagerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/domain/service/SeatManagerTest.java
@@ -80,7 +80,7 @@ class SeatManagerTest {
         seatManager.reserveSeats(seats, scheduleId, userId, sessionId);
 
         assertThat(seat1.isAvailable()).isFalse();
-        assertThat(seat1.isAvailable()).isFalse();
+        assertThat(seat2.isAvailable()).isFalse();
         verify(seatHoldManager).releaseAll(seatIds, scheduleId, userId, sessionId);
     }
 

--- a/src/test/java/com/firstticket/bookingservice/seat/domain/service/SeatManagerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/domain/service/SeatManagerTest.java
@@ -1,0 +1,103 @@
+package com.firstticket.bookingservice.seat.domain.service;
+
+import com.firstticket.bookingservice.seat.domain.Seat;
+import com.firstticket.bookingservice.seat.domain.SeatId;
+import com.firstticket.bookingservice.seat.domain.SeatPosition;
+import com.firstticket.bookingservice.seat.domain.exception.SeatErrorCode;
+import com.firstticket.bookingservice.seat.domain.exception.SeatException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SeatManagerTest {
+
+    @InjectMocks
+    private SeatManager seatManager;
+
+    @Mock
+    private SeatHoldManager seatHoldManager;
+    
+    private final UUID scheduleId = UUID.randomUUID();
+    private final UUID userId = UUID.randomUUID();
+    private final String sessionId = UUID.randomUUID().toString();
+    
+    @Test
+    @DisplayName("좌석 선점 성공 - 모든 좌석이 AVAILABLE이면 선점 등록")
+    void holdSeats_success() {
+        Seat seat1 = Seat.create(scheduleId, SeatPosition.of("A", 1 , 1), 10000);
+        Seat seat2 = Seat.create(scheduleId, SeatPosition.of("A", 1, 2), 10000);
+        List<Seat> seats = List.of(seat1, seat2);
+        
+        seatManager.holdSeats(seats, scheduleId, userId, sessionId);
+        
+        verify(seatHoldManager).hold(
+            seats.stream().map(Seat::getId).toList(),
+            scheduleId, userId, sessionId
+        );
+    }
+
+    @Test
+    @DisplayName("좌석 선점 실패 - AVAILABLE이 아닌 좌석 존재 시 SEAT_NOT_AVAILABLE 예외 발생")
+    void holdSeats_notAvailable() {
+        Seat availableSeat = Seat.create(scheduleId, SeatPosition.of("A", 1, 1), 10000);
+        Seat reservedSeat = Seat.create(scheduleId, SeatPosition.of("A", 1, 2), 10000);
+        reservedSeat.reserve();
+        List<Seat> seats = List.of(availableSeat, reservedSeat);
+
+        assertThatThrownBy(() -> seatManager.holdSeats(seats, scheduleId, userId, sessionId))
+            .isInstanceOf(SeatException.class)
+            .satisfies(e -> assertThat(((SeatException) e).getErrorCode())
+                .isEqualTo(SeatErrorCode.SEAT_NOT_AVAILABLE));
+
+        verify(seatHoldManager, never()).hold(anyList(), any(), any(), anyString());
+    }
+
+    @Test
+    @DisplayName("예매 확정 성공 - 선점 유효성 확인 후 RESERVED 상태로 변경")
+    void reserveSeats_success() {
+        Seat seat1 = Seat.create(scheduleId, SeatPosition.of("A", 1, 1), 10000);
+        Seat seat2 = Seat.create(scheduleId, SeatPosition.of("A", 1, 2), 10000);
+        List<Seat> seats = List.of(seat1, seat2);
+        List<SeatId> seatIds = seats.stream().map(Seat::getId).toList();
+
+        given(seatHoldManager.isHeld(seatIds, userId, sessionId)).willReturn(true);
+        given(seatHoldManager.releaseAll(seatIds, scheduleId, userId, sessionId)).willReturn(true);
+
+        seatManager.reserveSeats(seats, scheduleId, userId, sessionId);
+
+        assertThat(seat1.isAvailable()).isFalse();
+        assertThat(seat1.isAvailable()).isFalse();
+        verify(seatHoldManager).releaseAll(seatIds, scheduleId, userId, sessionId);
+    }
+
+    @Test
+    @DisplayName("예매 확정 실패 - 선점 유효성 확인 실패 시 SEAT_NOT_HELD 예외 발생")
+    void reserveSeats_notHeld() {
+        Seat seat = Seat.create(scheduleId, SeatPosition.of("A", 1, 1), 10000);
+        List<Seat> seats = List.of(seat);
+        List<SeatId> seatIds = seats.stream().map(Seat::getId).toList();
+
+        given(seatHoldManager.isHeld(seatIds, userId, sessionId)).willReturn(false);
+
+        assertThatThrownBy(() -> seatManager.reserveSeats(seats, scheduleId, userId, sessionId))
+            .isInstanceOf(SeatException.class)
+            .satisfies(e -> assertThat(((SeatException) e).getErrorCode())
+                .isEqualTo(SeatErrorCode.SEAT_NOT_HELD));
+
+        verify(seatHoldManager, never()).releaseAll(anyList(), any(), any(), anyString());
+    }
+}

--- a/src/test/java/com/firstticket/bookingservice/seat/infrastructure/redis/RedissonSeatHoldManagerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/infrastructure/redis/RedissonSeatHoldManagerTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Testcontainers
-public class RedissonSeatHoldManagerTest {
+class RedissonSeatHoldManagerTest {
 
     @Container
     static RedisContainer redis = new RedisContainer(


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

- `SeatManager` 도메인 서비스 구현
  - `holdSeats()` - AVAILABLE 상태 확인 후 선점
  - `reserveSeats()` - 선점 유효성 확인 후 RESERVED 상태 변경 및 선점 해제
  - `releaseSeats()` - 선점 해제
  - `validateHold()` - 선점 유효성 확인
  - `getHeldSeats()` - 선점 중인 좌석 목록 조회
- `Seat` 엔티티에서 `hold()`, `release()` 메서드 삭제
- `SeatManager` 단위 테스트 작성


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- close #12


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->



---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 좌석 보류·예약 흐름을 전담하는 도메인 서비스 추가

* **버그 수정**
  * 이미 예약된 좌석의 재예약 시도에 대한 검증 및 충돌 처리 강화
  * 보류 검증 실패 시 명확한 충돌 오류 반환 및 이후 처리 차단

* **기타**
  * 좌석 관련 충돌 오류 코드(이미 예약됨/보류 정보 없음) 추가

* **테스트**
  * 보류·예약 성공·실패 경로를 검증하는 테스트 스위트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->