### PR TITLE
[feat][booking-service] 좌석 선점 / 선점 취소 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'com.redis:testcontainers-redis:2.2.2'
 
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
@@ -1,0 +1,37 @@
+package com.firstticket.bookingservice.seat.application;
+
+import com.firstticket.bookingservice.seat.application.dto.command.HoldSeatsCommand;
+import com.firstticket.bookingservice.seat.domain.Seat;
+import com.firstticket.bookingservice.seat.domain.SeatId;
+import com.firstticket.bookingservice.seat.domain.SeatRepository;
+import com.firstticket.bookingservice.seat.domain.exception.SeatErrorCode;
+import com.firstticket.bookingservice.seat.domain.exception.SeatException;
+import com.firstticket.bookingservice.seat.domain.service.SeatManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SeatCommandService {
+
+    private final SeatRepository seatRepository;
+    private final SeatManager seatManager;
+
+    @Transactional
+    public void holdSeats(HoldSeatsCommand command, UUID userId, String sessionId) {
+        List<SeatId> seatIds = command.seatIds().stream()
+            .map(SeatId::of)
+            .toList();
+
+        List<Seat> seats = seatRepository.findAllByIdInAndScheduleId(seatIds, command.scheduleId());
+        if (seats.size() != seatIds.size()) {
+            throw new SeatException(SeatErrorCode.SEAT_NOT_FOUND);
+        }
+
+        seatManager.holdSeats(seats, command.scheduleId(), userId, sessionId);
+    }
+}

--- a/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
@@ -34,4 +34,11 @@ public class SeatCommandService {
 
         seatManager.holdSeats(seats, command.scheduleId(), userId, sessionId);
     }
+
+    @Transactional
+    public void releaseSeats(UUID scheduleId, UUID userId, String sessionId) {
+        List<SeatId> seatIds = seatManager.getHeldSeats(sessionId);
+        seatManager.releaseSeats(seatIds, scheduleId, userId, sessionId);
+    }
+
 }

--- a/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
@@ -25,6 +25,7 @@ public class SeatCommandService {
     public void holdSeats(HoldSeatsCommand command, UUID userId, String sessionId) {
         List<SeatId> seatIds = command.seatIds().stream()
             .map(SeatId::of)
+            .distinct()
             .toList();
 
         List<Seat> seats = seatRepository.findAllByIdInAndScheduleId(seatIds, command.scheduleId());

--- a/src/main/java/com/firstticket/bookingservice/seat/application/dto/command/HoldSeatsCommand.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/dto/command/HoldSeatsCommand.java
@@ -1,0 +1,9 @@
+package com.firstticket.bookingservice.seat.application.dto.command;
+
+import java.util.List;
+import java.util.UUID;
+
+public record HoldSeatsCommand(
+    List<UUID> seatIds,
+    UUID scheduleId
+) {}

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
@@ -1,0 +1,34 @@
+package com.firstticket.bookingservice.seat.presentation;
+
+import com.firstticket.bookingservice.seat.application.SeatCommandService;
+import com.firstticket.bookingservice.seat.presentation.dto.request.HoldSeatsRequest;
+import com.firstticket.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/seats")
+public class SeatController {
+
+    private final SeatCommandService seatCommandService;
+
+    @PostMapping("/schedules/{scheduleId}/hold")
+    public ResponseEntity<ApiResponse<Void>> holdSeats(
+        @PathVariable UUID scheduleId,
+        @RequestBody HoldSeatsRequest request,
+        @RequestHeader("X-User-Id") UUID userId,
+        @RequestHeader("X-Session-Id") String sessionId
+    ) {
+        seatCommandService.holdSeats(request.toCommand(scheduleId), userId, sessionId);
+        return ApiResponse.success(SeatSuccessCode.SEAT_HELD);
+    }
+}

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
@@ -3,6 +3,7 @@ package com.firstticket.bookingservice.seat.presentation;
 import com.firstticket.bookingservice.seat.application.SeatCommandService;
 import com.firstticket.bookingservice.seat.presentation.dto.request.HoldSeatsRequest;
 import com.firstticket.common.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,7 +26,7 @@ public class SeatController {
     @PostMapping("/schedules/{scheduleId}/hold")
     public ResponseEntity<ApiResponse<Void>> holdSeats(
         @PathVariable UUID scheduleId,
-        @RequestBody HoldSeatsRequest request,
+        @Valid @RequestBody HoldSeatsRequest request,
         @RequestHeader("X-User-Id") UUID userId,
         @RequestHeader("X-Session-Id") String sessionId
     ) {

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
@@ -5,6 +5,7 @@ import com.firstticket.bookingservice.seat.presentation.dto.request.HoldSeatsReq
 import com.firstticket.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,5 +31,15 @@ public class SeatController {
     ) {
         seatCommandService.holdSeats(request.toCommand(scheduleId), userId, sessionId);
         return ApiResponse.success(SeatSuccessCode.SEAT_HELD);
+    }
+
+    @DeleteMapping("/schedules/{scheduleId}/hold")
+    public ResponseEntity<ApiResponse<Void>> releaseSeats(
+        @PathVariable UUID scheduleId,
+        @RequestHeader("X-User-Id") UUID userId,
+        @RequestHeader("X-Session-Id") String sessionId
+    ) {
+        seatCommandService.releaseSeats(scheduleId, userId, sessionId);
+        return ApiResponse.success(SeatSuccessCode.SEAT_RELEASED);
     }
 }

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatSuccessCode.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SeatSuccessCode implements SuccessCode {
 
-    SEAT_HELD(HttpStatus.OK, "좌석 선점이 완료되었습니다.");
+    SEAT_HELD(HttpStatus.OK, "좌석 선점이 완료되었습니다."),
+    SEAT_RELEASED(HttpStatus.OK, "좌석 선점이 해제되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatSuccessCode.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatSuccessCode.java
@@ -1,0 +1,16 @@
+package com.firstticket.bookingservice.seat.presentation;
+
+import com.firstticket.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatSuccessCode implements SuccessCode {
+
+    SEAT_HELD(HttpStatus.OK, "좌석 선점이 완료되었습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/dto/request/HoldSeatsRequest.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/dto/request/HoldSeatsRequest.java
@@ -1,11 +1,13 @@
 package com.firstticket.bookingservice.seat.presentation.dto.request;
 
 import com.firstticket.bookingservice.seat.application.dto.command.HoldSeatsCommand;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 import java.util.UUID;
 
 public record HoldSeatsRequest(
+    @NotEmpty
     List<UUID> seatIds
 ) {
     public HoldSeatsCommand toCommand(UUID scheduleId) {

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/dto/request/HoldSeatsRequest.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/dto/request/HoldSeatsRequest.java
@@ -1,0 +1,14 @@
+package com.firstticket.bookingservice.seat.presentation.dto.request;
+
+import com.firstticket.bookingservice.seat.application.dto.command.HoldSeatsCommand;
+
+import java.util.List;
+import java.util.UUID;
+
+public record HoldSeatsRequest(
+    List<UUID> seatIds
+) {
+    public HoldSeatsCommand toCommand(UUID scheduleId) {
+        return new HoldSeatsCommand(seatIds, scheduleId);
+    }
+}

--- a/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
@@ -1,0 +1,146 @@
+package com.firstticket.bookingservice.seat.presentation;
+
+import com.firstticket.bookingservice.seat.application.SeatCommandService;
+import com.firstticket.bookingservice.seat.domain.exception.SeatErrorCode;
+import com.firstticket.bookingservice.seat.domain.exception.SeatException;
+import com.firstticket.bookingservice.seat.domain.service.SeatManager;
+import com.firstticket.bookingservice.support.RestDocsSupport;
+import com.firstticket.common.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SeatController.class)
+@Import(GlobalExceptionHandler.class)
+class SeatControllerTest extends RestDocsSupport {
+
+    @MockitoBean
+    private SeatCommandService seatCommandService;
+
+    @MockitoBean
+    private SeatManager seatManager;
+
+    private final UUID scheduleId = UUID.randomUUID();
+    private final UUID userId = UUID.randomUUID();
+    private final String sessionId = UUID.randomUUID().toString();
+
+    @Test
+    @DisplayName("좌석 선점 성공")
+    void holdSeats_success() throws Exception {
+        willDoNothing()
+            .given(seatCommandService)
+            .holdSeats(any(), any(UUID.class), any(String.class));
+
+        mockMvc.perform(RestDocumentationRequestBuilders
+                .post("/api/v1/seats/schedules/{scheduleId}/hold", scheduleId)
+                .header("X-User-Id", userId)
+                .header("X-Session-Id", sessionId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                            "seatIds": ["%s", "%s"]
+                        }
+                        """.formatted(UUID.randomUUID(), UUID.randomUUID())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("SEAT_HELD"))
+            .andDo(document("seat-hold-success",
+                requestHeaders(
+                    headerWithName("X-User-Id").description("사용자 ID"),
+                    headerWithName("X-Session-Id").description("예매 세션 ID")
+                ),
+                pathParameters(
+                    parameterWithName("scheduleId").description("회차 ID")
+                ),
+                requestFields(
+                    fieldWithPath("seatIds").description("선점할 좌석 ID 목록")
+                ),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("timestamp").description("응답 시간")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("이미 선점된 좌석 선점 시도 시 409 반환")
+    void holdSeats_alreadyHeld() throws Exception {
+        willThrow(new SeatException(SeatErrorCode.SEAT_ALREADY_HELD))
+            .given(seatCommandService)
+            .holdSeats(any(), any(UUID.class), any(String.class));
+
+        mockMvc.perform(RestDocumentationRequestBuilders
+                .post("/api/v1/seats/schedules/{scheduleId}/hold", scheduleId)
+                .header("X-User-Id", userId)
+                .header("X-Session-Id", sessionId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                            "seatIds": ["%s"]
+                        }
+                        """.formatted(UUID.randomUUID())))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.success").value(false))
+            .andDo(document("seat-hold-already-held",
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("에러 코드"),
+                    fieldWithPath("message").description("에러 메시지"),
+                    fieldWithPath("timestamp").description("응답 시간")
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("좌석 선점 취소 성공")
+    void releaseSeats_success() throws Exception {
+        willDoNothing()
+            .given(seatCommandService)
+            .releaseSeats(any(UUID.class), any(UUID.class), any(String.class));
+
+        mockMvc.perform(RestDocumentationRequestBuilders
+                .delete("/api/v1/seats/schedules/{scheduleId}/hold", scheduleId)
+                .header("X-User-Id", userId)
+                .header("X-Session-Id", sessionId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("SEAT_RELEASED"))
+            .andDo(document("seat-release-success",
+                requestHeaders(
+                    headerWithName("X-User-Id").description("사용자 ID"),
+                    headerWithName("X-Session-Id").description("예매 세션 ID")
+                ),
+                pathParameters(
+                    parameterWithName("scheduleId").description("회차 ID")
+                ),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("timestamp").description("응답 시간")
+                )
+            ));
+    }
+}

--- a/src/test/java/com/firstticket/bookingservice/support/RestDocsSupport.java
+++ b/src/test/java/com/firstticket/bookingservice/support/RestDocsSupport.java
@@ -1,0 +1,24 @@
+package com.firstticket.bookingservice.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsSupport {
+
+    protected MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .apply(documentationConfiguration(provider))
+            .build();
+    }
+}


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 좌석 선점 API 구현: `POST /api/v1/seats/schedules/{scheduleId}/hold`
- 좌석 선점 취소 API 구현: `DELETE /api/v1/seats/schedules/{scheduleId}/hold`
- RestDocs 의존성 추가 & 테스트 지원 클래스 추가
- 좌석 선점/선점 취소 API 테스트 코드 작성

## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- close #16


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
- `RestDocsSupport` 추가했으니 컨트롤러 테스트코드 작성 시 상속받아서 사용하시면 됩니다.


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 좌석 선점 및 해제 REST API 추가 — 스케줄 범위에서 좌석을 선점하고 해제할 수 있음.
  * 사용자 및 세션 기반으로 선점된 좌석 관리 및 추적 지원.

* **Tests**
  * 컨트롤러 동작을 검증하는 단위/통합 테스트 및 문서화용 테스트 스위트 추가.

* **Chores**
  * 테스트 실행 시 REST 문서 생성을 지원하는 테스트 의존성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->