### PR TITLE
[feat][booking-service] 좌석 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/firstticket/bookingservice/seat/application/SeatQueryService.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/SeatQueryService.java
@@ -1,0 +1,67 @@
+package com.firstticket.bookingservice.seat.application;
+
+import com.firstticket.bookingservice.seat.application.dto.result.SeatResult;
+import com.firstticket.bookingservice.seat.domain.Seat;
+import com.firstticket.bookingservice.seat.domain.SeatId;
+import com.firstticket.bookingservice.seat.domain.SeatRepository;
+import com.firstticket.bookingservice.seat.domain.SeatStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SeatQueryService {
+
+    private final SeatRepository seatRepository;
+
+    @Transactional(readOnly = true)
+    public SeatResult getSeatList(UUID scheduleId) {
+        List<Seat> seats = seatRepository.findByScheduleId(scheduleId);
+        Set<SeatId> heldSeatIds = seatRepository.findHeldSeatIds(
+            seats.stream().map(Seat::getId).toList()
+        );
+
+        int totalRemaining = countAvailable(seats);
+        List<SeatResult.SectionItem> sections = groupBySection(seats, heldSeatIds);
+
+        return SeatResult.of(scheduleId, totalRemaining, sections);
+    }
+
+    private int countAvailable(List<Seat> seats) {
+        return (int) seats.stream()
+            .filter(seat -> seat.getStatus() == SeatStatus.AVAILABLE)
+            .count();
+    }
+
+    private List<SeatResult.SectionItem> groupBySection(List<Seat> seats, Set<SeatId> heldSeatIds) {
+        return seats.stream()
+            .collect(Collectors.groupingBy(seat -> seat.getSection().sectionName()))
+            .entrySet().stream()
+            .map(entry -> toSectionItem(entry.getKey(), entry.getValue(), heldSeatIds))
+            .toList();
+    }
+
+    private SeatResult.SectionItem toSectionItem(String sectionName, List<Seat> seats, Set<SeatId> heldSeatIds) {
+        int remainingCount = countAvailable(seats);
+        List<SeatResult.SeatItem> seatItems = seats.stream()
+            .map(seat -> toSeatItem(seat, heldSeatIds))
+            .toList();
+        return new SeatResult.SectionItem(sectionName, remainingCount, seatItems);
+    }
+
+    private SeatResult.SeatItem toSeatItem(Seat seat, Set<SeatId> heldSeatIds) {
+        SeatStatus status = heldSeatIds.contains(seat.getId())
+            ? SeatStatus.HELD : seat.getStatus();
+
+        return switch (seat.getSeatType()) {
+            case SEATED -> SeatResult.SeatedItem.from(seat, status);
+            case STANDING -> SeatResult.StandingItem.from(seat, status);
+        };
+    }
+}

--- a/src/main/java/com/firstticket/bookingservice/seat/application/SeatQueryService.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/SeatQueryService.java
@@ -5,6 +5,8 @@ import com.firstticket.bookingservice.seat.domain.Seat;
 import com.firstticket.bookingservice.seat.domain.SeatId;
 import com.firstticket.bookingservice.seat.domain.SeatRepository;
 import com.firstticket.bookingservice.seat.domain.SeatStatus;
+import com.firstticket.bookingservice.seat.domain.exception.SeatErrorCode;
+import com.firstticket.bookingservice.seat.domain.exception.SeatException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +25,10 @@ public class SeatQueryService {
     @Transactional(readOnly = true)
     public SeatResult getSeatList(UUID scheduleId) {
         List<Seat> seats = seatRepository.findByScheduleId(scheduleId);
+        if (seats.isEmpty()) {
+            throw new SeatException(SeatErrorCode.SEAT_NOT_FOUND);
+        }
+
         Set<SeatId> heldSeatIds = seatRepository.findHeldSeatIds(
             seats.stream().map(Seat::getId).toList()
         );

--- a/src/main/java/com/firstticket/bookingservice/seat/application/dto/result/SeatResult.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/dto/result/SeatResult.java
@@ -1,0 +1,59 @@
+package com.firstticket.bookingservice.seat.application.dto.result;
+
+import com.firstticket.bookingservice.seat.domain.Seat;
+import com.firstticket.bookingservice.seat.domain.SeatStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+public record SeatResult(
+    UUID scheduleId,
+    int remainingCount,
+    List<SectionItem> sections
+) {
+    public static SeatResult of(UUID scheduleId, int remainingCount, List<SectionItem> sections) {
+        return new SeatResult(scheduleId, remainingCount, sections);
+    }
+
+    public record SectionItem(
+        String sectionName,
+        int remainingCount,
+        List<SeatItem> seats
+    ) {}
+
+    public sealed interface SeatItem permits SeatedItem, StandingItem {}
+
+    public record SeatedItem(
+        UUID seatId,
+        int rowNum,
+        int colNum,
+        int price,
+        String status
+    ) implements SeatItem {
+        public static SeatedItem from(Seat seat, SeatStatus status) {
+            return new SeatedItem(
+                seat.getId().id(),
+                seat.getSeatedInfo().rowNum(),
+                seat.getSeatedInfo().colNum(),
+                seat.getPrice(),
+                status.name()
+            );
+        }
+    }
+
+    public record StandingItem(
+        UUID seatId,
+        int entryNum,
+        int price,
+        String status
+    ) implements SeatItem {
+        public static StandingItem from(Seat seat, SeatStatus status) {
+            return new StandingItem(
+                seat.getId().id(),
+                seat.getStandingInfo().entryNum(),
+                seat.getPrice(),
+                status.name()
+            );
+        }
+    }
+}

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/SeatRepository.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/SeatRepository.java
@@ -2,6 +2,7 @@ package com.firstticket.bookingservice.seat.domain;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface SeatRepository {
@@ -13,4 +14,6 @@ public interface SeatRepository {
     List<Seat> findAllByIdInAndScheduleId(List<SeatId> ids, UUID scheduleId);
 
     List<Seat> saveAll(List<Seat> seats);
+
+    Set<SeatId> findHeldSeatIds(List<SeatId> seatIds);
 }

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/SeatStatus.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/SeatStatus.java
@@ -2,5 +2,6 @@ package com.firstticket.bookingservice.seat.domain;
 
 public enum SeatStatus {
     AVAILABLE,
-    RESERVED
+    RESERVED,
+    HELD // Redis TTL로만 관리, DB에 저장 X
 }

--- a/src/main/java/com/firstticket/bookingservice/seat/infrastructure/persistence/SeatRepositoryImpl.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/infrastructure/persistence/SeatRepositoryImpl.java
@@ -3,18 +3,24 @@ package com.firstticket.bookingservice.seat.infrastructure.persistence;
 import com.firstticket.bookingservice.seat.domain.Seat;
 import com.firstticket.bookingservice.seat.domain.SeatId;
 import com.firstticket.bookingservice.seat.domain.SeatRepository;
+import com.firstticket.bookingservice.seat.infrastructure.redis.SeatRedisRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
 public class SeatRepositoryImpl implements SeatRepository {
 
     private final SeatJpaRepository jpaRepository;
+    private final SeatRedisRepository redisRepository;
 
     @Override
     public Optional<Seat> findByIdAndScheduleId(SeatId id, UUID scheduleId) {
@@ -35,4 +41,11 @@ public class SeatRepositoryImpl implements SeatRepository {
     public List<Seat> saveAll(List<Seat> seats) {
         return jpaRepository.saveAll(seats);
     }
+
+    @Override
+    public Set<SeatId> findHeldSeatIds(List<SeatId> seatIds) {
+        return redisRepository.findHeldSeatIds(seatIds);
+    }
+
+
 }

--- a/src/main/java/com/firstticket/bookingservice/seat/infrastructure/redis/SeatRedisRepository.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/infrastructure/redis/SeatRedisRepository.java
@@ -1,0 +1,35 @@
+package com.firstticket.bookingservice.seat.infrastructure.redis;
+
+import com.firstticket.bookingservice.seat.domain.SeatId;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class SeatRedisRepository {
+
+    private final RedissonClient redissonClient;
+
+    public Set<SeatId> findHeldSeatIds(List<SeatId> seatIds) {
+        List<String> keys = seatIds.stream()
+            .map(this::holdKey)
+            .toList();
+
+        Map<String, String> buckets = redissonClient.getBuckets().get(keys.toArray(new String[0]));
+
+        return seatIds.stream()
+            .filter(id -> buckets.containsKey(holdKey(id)))
+            .collect(Collectors.toSet());
+    }
+
+    private String holdKey(SeatId seatId) {
+        return "held:" + seatId.id();
+    }
+}

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
@@ -1,12 +1,16 @@
 package com.firstticket.bookingservice.seat.presentation;
 
 import com.firstticket.bookingservice.seat.application.SeatCommandService;
+import com.firstticket.bookingservice.seat.application.SeatQueryService;
+import com.firstticket.bookingservice.seat.application.dto.result.SeatResult;
 import com.firstticket.bookingservice.seat.presentation.dto.request.SeatIdsRequest;
+import com.firstticket.bookingservice.seat.presentation.dto.response.SeatResponse;
 import com.firstticket.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +26,15 @@ import java.util.UUID;
 public class SeatController {
 
     private final SeatCommandService seatCommandService;
+    private final SeatQueryService seatQueryService;
+
+    @GetMapping("/schedules/{scheduleId}")
+    public ResponseEntity<ApiResponse<SeatResponse>> getSeatList(
+        @PathVariable UUID scheduleId
+    ) {
+        return ApiResponse.success(SeatSuccessCode.SEAT_LIST_OK,
+            SeatResponse.from(seatQueryService.getSeatList(scheduleId)));
+    }
 
     @PostMapping("/schedules/{scheduleId}/hold")
     public ResponseEntity<ApiResponse<Void>> holdSeats(

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatSuccessCode.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatSuccessCode.java
@@ -12,7 +12,8 @@ public enum SeatSuccessCode implements SuccessCode {
     SEAT_HELD(HttpStatus.OK, "좌석 선점이 완료되었습니다."),
     SEAT_RELEASED(HttpStatus.OK, "좌석 선점이 해제되었습니다."),
     SEAT_HOLD_VALID(HttpStatus.OK, "좌석 선점이 유효합니다."),
-    SEAT_RESERVED(HttpStatus.OK, "좌석이 확정되었습니다.");
+    SEAT_RESERVED(HttpStatus.OK, "좌석이 확정되었습니다."),
+    SEAT_LIST_OK(HttpStatus.OK, "좌석 목록 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/dto/response/SeatResponse.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/dto/response/SeatResponse.java
@@ -1,0 +1,70 @@
+package com.firstticket.bookingservice.seat.presentation.dto.response;
+
+import com.firstticket.bookingservice.seat.application.dto.result.SeatResult;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+public record SeatResponse(
+    UUID scheduleId,
+    int remainingCount,
+    List<SectionItem> sections
+) {
+    public record SectionItem(
+        String sectionName,
+        int remainingCount,
+        List<SeatItem> seats
+    ) {}
+
+    public abstract static class SeatItem {}
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class SeatedItem extends SeatItem {
+        private final UUID seatId;
+        private final int rowNum;
+        private final int colNum;
+        private final int price;
+        private final String status;
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class StandingItem extends SeatItem {
+        private final UUID seatId;
+        private final int entryNum;
+        private final int price;
+        private final String status;
+    }
+
+    public static SeatResponse from(SeatResult result) {
+        return new SeatResponse(
+            result.scheduleId(),
+            result.remainingCount(),
+            result.sections().stream()
+                .map(section -> new SectionItem(
+                    section.sectionName(),
+                    section.remainingCount(),
+                    section.seats().stream()
+                        .map(seat -> {
+                            if (seat instanceof SeatResult.SeatedItem(
+                                UUID seatId, int rowNum, int colNum, int price, String status
+                            )) {
+                                return new SeatedItem(seatId, rowNum, colNum, price, status);
+                            }
+                            else if (seat instanceof SeatResult.StandingItem(
+                                UUID seatId, int entryNum, int price, String status
+                            )) {
+                                return new StandingItem(seatId, entryNum, price, status);
+                            }
+                            throw new IllegalStateException("알 수 없는 좌석 타입");
+                        })
+                        .toList()
+                ))
+                .toList()
+        );
+    }
+}

--- a/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
@@ -1,6 +1,9 @@
 package com.firstticket.bookingservice.seat.presentation;
 
+import com.firstticket.bookingservice.global.token.BookingTokenProvider;
 import com.firstticket.bookingservice.seat.application.SeatCommandService;
+import com.firstticket.bookingservice.seat.application.SeatQueryService;
+import com.firstticket.bookingservice.seat.application.dto.result.SeatResult;
 import com.firstticket.bookingservice.seat.domain.exception.SeatErrorCode;
 import com.firstticket.bookingservice.seat.domain.exception.SeatException;
 import com.firstticket.bookingservice.seat.domain.service.SeatManager;
@@ -14,11 +17,11 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -38,11 +41,90 @@ class SeatControllerTest extends RestDocsSupport {
     private SeatCommandService seatCommandService;
 
     @MockitoBean
+    private SeatQueryService seatQueryService;
+
+    @MockitoBean
     private SeatManager seatManager;
+
+    @MockitoBean
+    private BookingTokenProvider bookingTokenProvider;
 
     private final UUID scheduleId = UUID.randomUUID();
     private final UUID userId = UUID.randomUUID();
     private final String sessionId = UUID.randomUUID().toString();
+
+    @Test
+    @DisplayName("좌석 목록 조회 성공")
+    void getSeatList_success() throws Exception {
+        UUID scheduleId = UUID.randomUUID();
+        UUID seatId1 = UUID.randomUUID();
+        UUID seatId2 = UUID.randomUUID();
+
+        SeatResult mockResult = SeatResult.of(
+            scheduleId,
+            2,
+            List.of(
+                new SeatResult.SectionItem(
+                    "A구역",
+                    2,
+                    List.of(
+                        new SeatResult.SeatedItem(seatId1, 1, 1, 50000, "AVAILABLE"),
+                        new SeatResult.StandingItem(seatId2, 1, 50000, "HELD")
+                    )
+                )
+            )
+        );
+
+        given(seatQueryService.getSeatList(any(UUID.class)))
+            .willReturn(mockResult);
+
+        mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/api/v1/seats/schedules/{scheduleId}", scheduleId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.code").value("SEAT_LIST_OK"))
+            .andDo(document("seat-list-success",
+                pathParameters(
+                    parameterWithName("scheduleId").description("회차 ID")
+                ),
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("timestamp").description("응답 시간"),
+                    fieldWithPath("data.scheduleId").description("회차 ID"),
+                    fieldWithPath("data.remainingCount").description("전체 잔여 좌석 수"),
+                    fieldWithPath("data.sections[].sectionName").description("구역명"),
+                    fieldWithPath("data.sections[].remainingCount").description("구역별 잔여 좌석 수"),
+                    fieldWithPath("data.sections[].seats[].seatId").description("좌석 ID"),
+                    fieldWithPath("data.sections[].seats[].price").description("좌석 가격"),
+                    fieldWithPath("data.sections[].seats[].status").description("좌석 상태 (AVAILABLE, HELD, RESERVED)"),
+                    fieldWithPath("data.sections[].seats[].rowNum").description("행 번호 (지정석만)").optional(),
+                    fieldWithPath("data.sections[].seats[].colNum").description("열 번호 (지정석만)").optional(),
+                    fieldWithPath("data.sections[].seats[].entryNum").description("입장 번호 (스탠딩석만)").optional()
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 scheduleId로 조회 시 404 반환")
+    void getSeatList_notFound() throws Exception {
+        given(seatQueryService.getSeatList(any(UUID.class)))
+            .willThrow(new SeatException(SeatErrorCode.SEAT_NOT_FOUND));
+
+        mockMvc.perform(RestDocumentationRequestBuilders
+                .get("/api/v1/seats/schedules/{scheduleId}", UUID.randomUUID()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.success").value(false))
+            .andDo(document("seat-list-not-found",
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("에러 코드"),
+                    fieldWithPath("message").description("에러 메시지"),
+                    fieldWithPath("timestamp").description("응답 시간")
+                )
+            ));
+    }
 
     @Test
     @DisplayName("좌석 선점 성공")


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->
- 좌석 목록 조회 외부 API 구현 (`GET /api/v1/seats/schedules/{scheduleId}`)
- DB의 AVAILABLE/RESERVED 상태와 Redis의 HELD 상태를 합산해 실시간 좌석 현황 제공
- Redis mget으로 선점 좌석 일괄 조회 후 HELD 상태 오버라이드
- 구역별 그룹핑 및 잔여 좌석 수 계산 후 응답
- RestDocs 테스트 코드 작성


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- close #32


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 공연 일정의 좌석 목록 조회 API 추가 — 섹션별로 정렬된 좌석 목록 제공
  * 좌석의 상태(예약 가능, 보류 중, 예약됨), 가격, 위치(열/열번호 또는 입장 번호) 및 섹션·전체 잔여 수 표시
  * 보류된 좌석 상태가 조회 결과에 반영되어 실시간 가용성 개선
  * 조회 성공/실패에 대한 명확한 응답 코드 및 메시지 제공

* **Tests**
  * 좌석 목록 조회 성공 및 조회 불가(404) 시나리오에 대한 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->