### PR TITLE
[refactor][booking-service] 좌석 선점/취소/조회 API 인증 처리 통합 및 권한·programId 검증 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
 }
 
 dependencies {
-    implementation 'com.first-ticket:common:0.0.3-SNAPSHOT'
+    implementation 'com.first-ticket:common:0.0.4-SNAPSHOT'
     implementation 'com.first-ticket:common-jpa:0.0.1-SNAPSHOT'
     implementation 'com.first-ticket:common-messaging:0.0.1-SNAPSHOT'
 

--- a/src/main/java/com/firstticket/bookingservice/global/resolver/BookingTokenResolver.java
+++ b/src/main/java/com/firstticket/bookingservice/global/resolver/BookingTokenResolver.java
@@ -4,6 +4,7 @@ import com.firstticket.bookingservice.booking.domain.exception.BookingErrorCode;
 import com.firstticket.bookingservice.booking.domain.exception.BookingException;
 import com.firstticket.bookingservice.global.annotation.BookingToken;
 import com.firstticket.bookingservice.global.token.BookingTokenClaims;
+import com.firstticket.bookingservice.global.token.BookingTokenExtractor;
 import com.firstticket.bookingservice.global.token.BookingTokenProvider;
 import java.util.UUID;
 
@@ -41,7 +42,7 @@ public class BookingTokenResolver implements HandlerMethodArgumentResolver {
             throw new BookingException(BookingErrorCode.EMPTY_SESSION_TOKEN);
         }
 
-        String token = sessionHeader.substring(7).trim();
+        String token = BookingTokenExtractor.extract(sessionHeader);
         if(token.isEmpty()){
             throw new BookingException(BookingErrorCode.EMPTY_SESSION_TOKEN);
         }

--- a/src/main/java/com/firstticket/bookingservice/global/resolver/BookingTokenResolver.java
+++ b/src/main/java/com/firstticket/bookingservice/global/resolver/BookingTokenResolver.java
@@ -6,6 +6,8 @@ import com.firstticket.bookingservice.global.annotation.BookingToken;
 import com.firstticket.bookingservice.global.token.BookingTokenClaims;
 import com.firstticket.bookingservice.global.token.BookingTokenProvider;
 import java.util.UUID;
+
+import com.firstticket.common.web.AuthContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -32,12 +34,6 @@ public class BookingTokenResolver implements HandlerMethodArgumentResolver {
     public BookingTokenClaims resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                               NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 
-        String xUserId = webRequest.getHeader("X-User-Id");
-
-        if(xUserId == null){
-            throw new BookingException(BookingErrorCode.EMPTY_X_USER_ID);
-        }
-
         // 세션 토큰 검증
         String sessionHeader = webRequest.getHeader("Booking-Session-Token");
 
@@ -53,14 +49,9 @@ public class BookingTokenResolver implements HandlerMethodArgumentResolver {
         // 세션 토큰 전용 시크릿으로 검증 후 반환
         BookingTokenClaims sessionTokenClaims = tokenProvider.validateSessionToken(token);
 
-        UUID userId;
-        try {
-            userId = UUID.fromString(xUserId);
-        } catch (IllegalArgumentException e) {
-            throw new BookingException(BookingErrorCode.INVALID_USER_ID);
-        }
+        UUID userId = AuthContext.getUserId();
 
-        if(!sessionTokenClaims.userId().equals(userId)){
+        if (!sessionTokenClaims.userId().equals(userId)) {
             throw new BookingException(BookingErrorCode.INVALID_USER_ID);
         }
 

--- a/src/main/java/com/firstticket/bookingservice/global/token/BookingTokenExtractor.java
+++ b/src/main/java/com/firstticket/bookingservice/global/token/BookingTokenExtractor.java
@@ -1,0 +1,9 @@
+package com.firstticket.bookingservice.global.token;
+
+public final class BookingTokenExtractor {
+    private BookingTokenExtractor() {}
+
+    public static String extract(String sessionToken) {
+        return sessionToken.substring(7).trim();
+    }
+}

--- a/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
@@ -63,8 +63,8 @@ public class SeatCommandService {
     }
 
     @Transactional
-    public void holdSeats(List<UUID> seatIds, UUID scheduleId, UUID userId, String sessionId) {
-        seatManager.holdSeats(getSeats(seatIds, scheduleId), scheduleId, userId, sessionId);
+    public void holdSeats(List<UUID> seatIds, UUID programId, UUID scheduleId, UUID userId, String sessionId) {
+        seatManager.holdSeats(getSeats(seatIds, scheduleId), programId, scheduleId, userId, sessionId);
     }
 
     @Transactional

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
@@ -17,7 +17,8 @@ public enum SeatErrorCode implements ErrorCode {
     SEAT_HOLD_FAILED(HttpStatus.CONFLICT, "이미 선택된 좌석입니다."),
     SEAT_NOT_AVAILABLE(HttpStatus.CONFLICT, "이미 예매된 좌석입니다."),
     SEAT_NOT_HELD(HttpStatus.CONFLICT, "선점 정보가 유효하지 않습니다."),
-    SEAT_ALREADY_RESERVED(HttpStatus.CONFLICT, "이미 예매된 좌석입니다.");
+    SEAT_ALREADY_RESERVED(HttpStatus.CONFLICT, "이미 예매된 좌석입니다."),
+    SEAT_PROGRAM_MISMATCH(HttpStatus.UNAUTHORIZED, "해당 프로그램에 대한 선점 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/exception/SeatErrorCode.java
@@ -18,7 +18,7 @@ public enum SeatErrorCode implements ErrorCode {
     SEAT_NOT_AVAILABLE(HttpStatus.CONFLICT, "이미 예매된 좌석입니다."),
     SEAT_NOT_HELD(HttpStatus.CONFLICT, "선점 정보가 유효하지 않습니다."),
     SEAT_ALREADY_RESERVED(HttpStatus.CONFLICT, "이미 예매된 좌석입니다."),
-    SEAT_PROGRAM_MISMATCH(HttpStatus.UNAUTHORIZED, "해당 프로그램에 대한 선점 권한이 없습니다.");
+    SEAT_PROGRAM_MISMATCH(HttpStatus.FORBIDDEN, "해당 프로그램에 대한 선점 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/service/SeatManager.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/service/SeatManager.java
@@ -16,8 +16,11 @@ public class SeatManager {
 
     private final SeatHoldManager seatHoldManager;
 
-    public void holdSeats(List<Seat> seats, UUID scheduleId, UUID userId, String sessionId) {
+    public void holdSeats(List<Seat> seats, UUID programId, UUID scheduleId, UUID userId, String sessionId) {
         for (Seat seat : seats) {
+            if (!seat.getProgramId().equals(programId)) {
+                throw new SeatException(SeatErrorCode.SEAT_PROGRAM_MISMATCH);
+            }
             if (!seat.isAvailable()) {
                 throw new SeatException(SeatErrorCode.SEAT_NOT_AVAILABLE);
             }

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
@@ -65,7 +65,7 @@ public class SeatController {
     ) {
         AuthContext.requireRole(UserRole.CUSTOMER);
         String token = BookingTokenExtractor.extract(sessionToken);
-        seatCommandService.holdSeats(request.seatIds(), scheduleId, claims.userId(), token);
+        seatCommandService.holdSeats(request.seatIds(), claims.programId(), scheduleId, claims.userId(), token);
         return ApiResponse.success(SeatSuccessCode.SEAT_HELD);
     }
 

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatController.java
@@ -2,12 +2,15 @@ package com.firstticket.bookingservice.seat.presentation;
 
 import com.firstticket.bookingservice.global.annotation.BookingToken;
 import com.firstticket.bookingservice.global.token.BookingTokenClaims;
+import com.firstticket.bookingservice.global.token.BookingTokenExtractor;
 import com.firstticket.bookingservice.seat.application.SeatCommandService;
 import com.firstticket.bookingservice.seat.application.SeatQueryService;
 import com.firstticket.bookingservice.seat.presentation.dto.request.SeatIdsRequest;
 import com.firstticket.bookingservice.seat.presentation.dto.response.HeldSeatItemResponse;
 import com.firstticket.bookingservice.seat.presentation.dto.response.SeatResponse;
 import com.firstticket.common.response.ApiResponse;
+import com.firstticket.common.web.AuthContext;
+import com.firstticket.common.web.UserRole;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -45,7 +48,8 @@ public class SeatController {
         @BookingToken BookingTokenClaims claims,
         @RequestHeader("Booking-Session-Token") String sessionToken
     ) {
-        String token = sessionToken.startsWith("Bearer ") ? sessionToken.substring(7).trim() : sessionToken;
+        AuthContext.requireRole(UserRole.CUSTOMER);
+        String token = BookingTokenExtractor.extract(sessionToken);
         return ApiResponse.success(SeatSuccessCode.SEAT_HELD_LIST_OK,
             seatQueryService.getHeldSeats(scheduleId, token).stream()
                 .map(HeldSeatItemResponse::from)
@@ -56,20 +60,24 @@ public class SeatController {
     public ResponseEntity<ApiResponse<Void>> holdSeats(
         @PathVariable UUID scheduleId,
         @Valid @RequestBody SeatIdsRequest request,
-        @RequestHeader("X-User-Id") UUID userId,
-        @RequestHeader("X-Session-Id") String sessionId
+        @BookingToken BookingTokenClaims claims,
+        @RequestHeader("Booking-Session-Token") String sessionToken
     ) {
-        seatCommandService.holdSeats(request.seatIds(), scheduleId, userId, sessionId);
+        AuthContext.requireRole(UserRole.CUSTOMER);
+        String token = BookingTokenExtractor.extract(sessionToken);
+        seatCommandService.holdSeats(request.seatIds(), scheduleId, claims.userId(), token);
         return ApiResponse.success(SeatSuccessCode.SEAT_HELD);
     }
 
     @DeleteMapping("/schedules/{scheduleId}/hold")
     public ResponseEntity<ApiResponse<Void>> releaseSeats(
         @PathVariable UUID scheduleId,
-        @RequestHeader("X-User-Id") UUID userId,
-        @RequestHeader("X-Session-Id") String sessionId
+        @BookingToken BookingTokenClaims claims,
+        @RequestHeader("Booking-Session-Token") String sessionToken
     ) {
-        seatCommandService.releaseSeats(scheduleId, userId, sessionId);
+        AuthContext.requireRole(UserRole.CUSTOMER);
+        String token = BookingTokenExtractor.extract(sessionToken);
+        seatCommandService.releaseSeats(scheduleId, claims.userId(), token);
         return ApiResponse.success(SeatSuccessCode.SEAT_RELEASED);
     }
 }

--- a/src/test/java/com/firstticket/bookingservice/seat/domain/service/SeatManagerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/domain/service/SeatManagerTest.java
@@ -45,7 +45,7 @@ class SeatManagerTest {
         Seat seat2 = Seat.createSeated(programId, scheduleId, section, SeatedInfo.of(1, 2), 10000);
         List<Seat> seats = List.of(seat1, seat2);
 
-        seatManager.holdSeats(seats, scheduleId, userId, sessionId);
+        seatManager.holdSeats(seats, programId, scheduleId, userId, sessionId);
 
         verify(seatHoldManager).hold(
             seats.stream().map(Seat::getId).toList(),
@@ -61,10 +61,25 @@ class SeatManagerTest {
         reservedSeat.reserve();
         List<Seat> seats = List.of(availableSeat, reservedSeat);
 
-        assertThatThrownBy(() -> seatManager.holdSeats(seats, scheduleId, userId, sessionId))
+        assertThatThrownBy(() -> seatManager.holdSeats(seats, programId, scheduleId, userId, sessionId))
             .isInstanceOf(SeatException.class)
             .satisfies(e -> assertThat(((SeatException) e).getErrorCode())
                 .isEqualTo(SeatErrorCode.SEAT_NOT_AVAILABLE));
+
+        verify(seatHoldManager, never()).hold(anyList(), any(), any(), anyString());
+    }
+
+    @Test
+    @DisplayName("좌석 선점 실패 - 다른 프로그램의 좌석 선점 시도 시 SEAT_PROGRAM_MISMATCH 예외 발생")
+    void holdSeats_programMismatch() {
+        UUID otherProgramId = UUID.randomUUID();
+        Seat seat = Seat.createSeated(otherProgramId, scheduleId, section, SeatedInfo.of(1, 1), 10000);
+        List<Seat> seats = List.of(seat);
+
+        assertThatThrownBy(() -> seatManager.holdSeats(seats, programId, scheduleId, userId, sessionId))
+            .isInstanceOf(SeatException.class)
+            .satisfies(e -> assertThat(((SeatException) e).getErrorCode())
+                .isEqualTo(SeatErrorCode.SEAT_PROGRAM_MISMATCH));
 
         verify(seatHoldManager, never()).hold(anyList(), any(), any(), anyString());
     }

--- a/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
@@ -54,7 +54,6 @@ class SeatControllerTest extends RestDocsSupport {
 
     private final UUID scheduleId = UUID.randomUUID();
     private final UUID userId = UUID.randomUUID();
-    private final String sessionId = UUID.randomUUID().toString();
 
     @Test
     @DisplayName("좌석 목록 조회 성공")
@@ -149,6 +148,7 @@ class SeatControllerTest extends RestDocsSupport {
         mockMvc.perform(RestDocumentationRequestBuilders
                 .get("/api/v1/seats/schedules/{scheduleId}/hold", scheduleId)
                 .header("X-User-Id", userId)
+                .header("X-User-Role", "CUSTOMER")
                 .header("Authorization", "Bearer test-access-token")
                 .header("Booking-Session-Token", "Bearer test-token"))
             .andExpect(status().isOk())
@@ -181,10 +181,15 @@ class SeatControllerTest extends RestDocsSupport {
             .given(seatCommandService)
             .holdSeats(any(), any(UUID.class), any(UUID.class), any(String.class));
 
+        given(bookingTokenProvider.validateSessionToken(any(String.class)))
+            .willReturn(new BookingTokenClaims(userId, UUID.randomUUID(), new Date()));
+
         mockMvc.perform(RestDocumentationRequestBuilders
                 .post("/api/v1/seats/schedules/{scheduleId}/hold", scheduleId)
                 .header("X-User-Id", userId)
-                .header("X-Session-Id", sessionId)
+                .header("X-User-Role", "CUSTOMER")
+                .header("Authorization", "Bearer test-access-token")
+                .header("Booking-Session-Token", "Bearer test-token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
                         {
@@ -196,8 +201,8 @@ class SeatControllerTest extends RestDocsSupport {
             .andExpect(jsonPath("$.code").value("SEAT_HELD"))
             .andDo(document("seat-hold-success",
                 requestHeaders(
-                    headerWithName("X-User-Id").description("사용자 ID"),
-                    headerWithName("X-Session-Id").description("예매 세션 ID")
+                    headerWithName("Authorization").description("JWT access token"),
+                    headerWithName("Booking-Session-Token").description("예매 세션 토큰")
                 ),
                 pathParameters(
                     parameterWithName("scheduleId").description("회차 ID")
@@ -219,12 +224,17 @@ class SeatControllerTest extends RestDocsSupport {
     void holdSeats_alreadyHeld() throws Exception {
         willThrow(new SeatException(SeatErrorCode.SEAT_ALREADY_HELD))
             .given(seatCommandService)
-            .holdSeats(any(),any(UUID.class), any(UUID.class), any(String.class));
+            .holdSeats(any(), any(UUID.class), any(UUID.class), any(String.class));
+
+        given(bookingTokenProvider.validateSessionToken(any(String.class)))
+            .willReturn(new BookingTokenClaims(userId, UUID.randomUUID(), new Date()));
 
         mockMvc.perform(RestDocumentationRequestBuilders
                 .post("/api/v1/seats/schedules/{scheduleId}/hold", scheduleId)
                 .header("X-User-Id", userId)
-                .header("X-Session-Id", sessionId)
+                .header("X-User-Role", "CUSTOMER")
+                .header("Authorization", "Bearer test-access-token")
+                .header("Booking-Session-Token", "Bearer test-token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
                         {
@@ -250,17 +260,22 @@ class SeatControllerTest extends RestDocsSupport {
             .given(seatCommandService)
             .releaseSeats(any(UUID.class), any(UUID.class), any(String.class));
 
+        given(bookingTokenProvider.validateSessionToken(any(String.class)))
+            .willReturn(new BookingTokenClaims(userId, UUID.randomUUID(), new Date()));
+
         mockMvc.perform(RestDocumentationRequestBuilders
                 .delete("/api/v1/seats/schedules/{scheduleId}/hold", scheduleId)
                 .header("X-User-Id", userId)
-                .header("X-Session-Id", sessionId))
+                .header("X-User-Role", "CUSTOMER")
+                .header("Authorization", "Bearer test-access-token")
+                .header("Booking-Session-Token", "Bearer test-token"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.code").value("SEAT_RELEASED"))
             .andDo(document("seat-release-success",
                 requestHeaders(
-                    headerWithName("X-User-Id").description("사용자 ID"),
-                    headerWithName("X-Session-Id").description("예매 세션 ID")
+                    headerWithName("Authorization").description("JWT access token"),
+                    headerWithName("Booking-Session-Token").description("예매 세션 토큰")
                 ),
                 pathParameters(
                     parameterWithName("scheduleId").description("회차 ID")

--- a/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
@@ -179,7 +179,7 @@ class SeatControllerTest extends RestDocsSupport {
     void holdSeats_success() throws Exception {
         willDoNothing()
             .given(seatCommandService)
-            .holdSeats(any(), any(UUID.class), any(UUID.class), any(String.class));
+            .holdSeats(any(), any(UUID.class), any(UUID.class), any(UUID.class), any(String.class));
 
         given(bookingTokenProvider.validateSessionToken(any(String.class)))
             .willReturn(new BookingTokenClaims(userId, UUID.randomUUID(), new Date()));
@@ -224,7 +224,7 @@ class SeatControllerTest extends RestDocsSupport {
     void holdSeats_alreadyHeld() throws Exception {
         willThrow(new SeatException(SeatErrorCode.SEAT_ALREADY_HELD))
             .given(seatCommandService)
-            .holdSeats(any(), any(UUID.class), any(UUID.class), any(String.class));
+            .holdSeats(any(), any(UUID.class), any(UUID.class), any(UUID.class), any(String.class));
 
         given(bookingTokenProvider.validateSessionToken(any(String.class)))
             .willReturn(new BookingTokenClaims(userId, UUID.randomUUID(), new Date()));

--- a/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatControllerTest.java
@@ -254,6 +254,40 @@ class SeatControllerTest extends RestDocsSupport {
     }
 
     @Test
+    @DisplayName("다른 프로그램 좌석 선점 시도 시 401 반환")
+    void holdSeats_programMismatch() throws Exception {
+        willThrow(new SeatException(SeatErrorCode.SEAT_PROGRAM_MISMATCH))
+            .given(seatCommandService)
+            .holdSeats(any(), any(UUID.class), any(UUID.class), any(UUID.class), any(String.class));
+
+        given(bookingTokenProvider.validateSessionToken(any(String.class)))
+            .willReturn(new BookingTokenClaims(userId, UUID.randomUUID(), new Date()));
+
+        mockMvc.perform(RestDocumentationRequestBuilders
+                .post("/api/v1/seats/schedules/{scheduleId}/hold", scheduleId)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "CUSTOMER")
+                .header("Authorization", "Bearer test-access-token")
+                .header("Booking-Session-Token", "Bearer test-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "seatIds": ["%s"]
+                    }
+                    """.formatted(UUID.randomUUID())))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.success").value(false))
+            .andDo(document("seat-hold-program-mismatch",
+                responseFields(
+                    fieldWithPath("success").description("성공 여부"),
+                    fieldWithPath("code").description("에러 코드"),
+                    fieldWithPath("message").description("에러 메시지"),
+                    fieldWithPath("timestamp").description("응답 시간")
+                )
+            ));
+    }
+
+    @Test
     @DisplayName("좌석 선점 취소 성공")
     void releaseSeats_success() throws Exception {
         willDoNothing()


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->
- common 모듈 버전 0.0.4-SNAPSHOT으로 업데이트
- 좌석 선점/취소/조회 API에 `@BookingToken` 적용으로 인증 처리 통합
- `BookingTokenResolver`에서 `X-User-Id` 추출을 `AuthContext.getUserId()`로 교체
- `Bearer` 파싱 로직을 `BookingTokenExtractor` 유틸로 분리
- `AuthContext.requireRole(UserRole.CUSTOMER)`로 구매자 권한 검증 추가
- 좌석 선점 시 토큰의 `programId`와 좌석의 `programId` 일치 여부 검증 추가 (`SeatManager`)
- 테스트 코드 수정 및 `programId` 불일치 케이스 추가


## 📌 관련 이슈
- close #36


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [x] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [x] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
global에 `BookingTokenExtractor` 유틸 추가했습니다
  - Booking-Session-Token 헤더에서 Bearer 접두사를 제거하고 순수 토큰 값을 추출할 때 사용합니다.
  - 토큰을 파라미터로 넘겨야할 때 사용하시면 됩니다
    ```java
    @RequestHeader("Booking-Session-Token") String sessionToken
    String token = BookingTokenExtractor.extract(sessionToken);
    ```
---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 좌석 선점 시 프로그램 단위 권한 검증 추가

* **보안 개선**
  * 예약 세션 토큰 인증 강화 및 토큰 추출 로직 표준화
  * 요청 인증 헤더 검증 및 역할 기반 접근 강화

* **오류 처리**
  * 프로그램 불일치 시 명확한 권한 오류(403) 응답 추가

* **테스트·문서**
  * 관련 단위/통합 테스트 및 API 헤더 문서 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->