### PR TITLE
[documentation][booking-service] REST Docs AsciiDoc 연결 & 좌석 API 문서화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 ### env ###
 .env
+
+src/main/resources/static/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '4.0.0'
 }
 
 group = 'com.first-ticket'
@@ -57,8 +58,13 @@ repositories {
     }
 }
 
+configurations {
+    asciidoctorExt
+}
+
 ext {
     set('springCloudVersion', "2025.0.2")
+    snippetsDir = file('build/generated-snippets')
 }
 
 dependencies {
@@ -100,10 +106,11 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'com.redis:testcontainers-redis:2.2.2'
-
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
@@ -118,10 +125,45 @@ dependencyManagement {
     }
 }
 
+test {
+    outputs.dir snippetsDir
+}
+
 tasks.named('bootBuildImage') {
     runImage = 'paketobuildpacks/ubuntu-noble-run:latest'
 }
 
 tasks.named('test') {
+    outputs.dir snippetsDir
     useJUnitPlatform()
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    dependsOn test
+    configurations 'asciidoctorExt'
+    baseDirFollowsSourceFile()
+}
+
+tasks.named('asciidoctor') {
+    doFirst {
+        delete file('src/main/resources/static/docs')
+    }
+}
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from layout.buildDirectory.dir("docs/asciidoc")
+    into layout.projectDirectory.dir("src/main/resources/static/docs")
+}
+
+tasks.named('build') {
+    dependsOn copyDocument
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from(layout.buildDirectory.dir("docs/asciidoc")) {
+        into 'static/docs'
+    }
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -3,74 +3,61 @@
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 
-== 공통 응답 형식
+== 개요
+
+좌석 목록 조회 / 선점 / 선점 취소 / 선점 목록 조회 / 잔여 좌석 수 조회 API.
+
+=== 인증
+
+`Authorization` 헤더에 JWT access token을 담아 요청한다.
+선점 관련 API는 추가로 `Booking-Session-Token` 헤더가 필요하다.
+
+=== 응답 형식
+
+성공 / 실패 모두 `ApiResponse<T>` 형식으로 응답한다.
 
 [source,json]
 ----
 {
   "success": true,
-  "code": "SUCCESS_CODE",
-  "message": "응답 메시지",
-  "timestamp": "2025-04-21T10:05:00",
+  "code": "SEAT_LIST_OK",
+  "message": "좌석 목록 조회에 성공했습니다.",
+  "timestamp": "2026-04-21T10:05:00",
   "data": {}
 }
 ----
 
-== 좌석 API
+== 좌석 목록 조회
 
-=== 좌석 목록 조회
+operation::seat-list-success[snippets='http-request,path-parameters,http-response,response-fields']
 
-==== 요청
-include::{snippets}/seat-list-success/http-request.adoc[]
-include::{snippets}/seat-list-success/path-parameters.adoc[]
+== 좌석 선점
 
-==== 응답
-include::{snippets}/seat-list-success/http-response.adoc[]
-include::{snippets}/seat-list-success/response-fields.adoc[]
+operation::seat-hold-success[snippets='http-request,path-parameters,request-headers,request-fields,http-response,response-fields']
 
-=== 좌석 선점
+=== 에러 응답
 
-==== 요청
-include::{snippets}/seat-hold-success/http-request.adoc[]
-include::{snippets}/seat-hold-success/path-parameters.adoc[]
-include::{snippets}/seat-hold-success/request-headers.adoc[]
-include::{snippets}/seat-hold-success/request-fields.adoc[]
+==== 이미 선점된 좌석 (409)
 
-==== 응답
-include::{snippets}/seat-hold-success/http-response.adoc[]
-include::{snippets}/seat-hold-success/response-fields.adoc[]
+include::{snippets}/seat-hold-already-held/http-response.adoc[]
+include::{snippets}/seat-hold-already-held/response-fields.adoc[]
 
-=== 좌석 선점 취소
+==== 다른 프로그램 좌석 선점 시도 (403)
 
-==== 요청
-include::{snippets}/seat-release-success/http-request.adoc[]
-include::{snippets}/seat-release-success/path-parameters.adoc[]
-include::{snippets}/seat-release-success/request-headers.adoc[]
+include::{snippets}/seat-hold-program-mismatch/http-response.adoc[]
+include::{snippets}/seat-hold-program-mismatch/response-fields.adoc[]
 
-==== 응답
-include::{snippets}/seat-release-success/http-response.adoc[]
-include::{snippets}/seat-release-success/response-fields.adoc[]
+== 좌석 선점 취소
 
-=== 선점 중인 좌석 조회
+operation::seat-release-success[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
-==== 요청
-include::{snippets}/seat-held-list-success/http-request.adoc[]
-include::{snippets}/seat-held-list-success/path-parameters.adoc[]
-include::{snippets}/seat-held-list-success/request-headers.adoc[]
+== 선점 중인 좌석 조회
 
-==== 응답
-include::{snippets}/seat-held-list-success/http-response.adoc[]
-include::{snippets}/seat-held-list-success/response-fields.adoc[]
+operation::seat-held-list-success[snippets='http-request,path-parameters,request-headers,http-response,response-fields']
 
-=== 회차별 잔여 좌석 수 조회
+== 회차별 잔여 좌석 수 조회 (내부 API)
 
-==== 요청
-include::{snippets}/seat-remaining-success/http-request.adoc[]
-include::{snippets}/seat-remaining-success/path-parameters.adoc[]
-
-==== 응답
-include::{snippets}/seat-remaining-success/http-response.adoc[]
-include::{snippets}/seat-remaining-success/response-fields.adoc[]
+operation::seat-remaining-success[snippets='http-request,path-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,76 @@
+= Booking Service API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+== 공통 응답 형식
+
+[source,json]
+----
+{
+  "success": true,
+  "code": "SUCCESS_CODE",
+  "message": "응답 메시지",
+  "timestamp": "2025-04-21T10:05:00",
+  "data": {}
+}
+----
+
+== 좌석 API
+
+=== 좌석 목록 조회
+
+==== 요청
+include::{snippets}/seat-list-success/http-request.adoc[]
+include::{snippets}/seat-list-success/path-parameters.adoc[]
+
+==== 응답
+include::{snippets}/seat-list-success/http-response.adoc[]
+include::{snippets}/seat-list-success/response-fields.adoc[]
+
+=== 좌석 선점
+
+==== 요청
+include::{snippets}/seat-hold-success/http-request.adoc[]
+include::{snippets}/seat-hold-success/path-parameters.adoc[]
+include::{snippets}/seat-hold-success/request-headers.adoc[]
+include::{snippets}/seat-hold-success/request-fields.adoc[]
+
+==== 응답
+include::{snippets}/seat-hold-success/http-response.adoc[]
+include::{snippets}/seat-hold-success/response-fields.adoc[]
+
+=== 좌석 선점 취소
+
+==== 요청
+include::{snippets}/seat-release-success/http-request.adoc[]
+include::{snippets}/seat-release-success/path-parameters.adoc[]
+include::{snippets}/seat-release-success/request-headers.adoc[]
+
+==== 응답
+include::{snippets}/seat-release-success/http-response.adoc[]
+include::{snippets}/seat-release-success/response-fields.adoc[]
+
+=== 선점 중인 좌석 조회
+
+==== 요청
+include::{snippets}/seat-held-list-success/http-request.adoc[]
+include::{snippets}/seat-held-list-success/path-parameters.adoc[]
+include::{snippets}/seat-held-list-success/request-headers.adoc[]
+
+==== 응답
+include::{snippets}/seat-held-list-success/http-response.adoc[]
+include::{snippets}/seat-held-list-success/response-fields.adoc[]
+
+=== 회차별 잔여 좌석 수 조회
+
+==== 요청
+include::{snippets}/seat-remaining-success/http-request.adoc[]
+include::{snippets}/seat-remaining-success/path-parameters.adoc[]
+
+==== 응답
+include::{snippets}/seat-remaining-success/http-response.adoc[]
+include::{snippets}/seat-remaining-success/response-fields.adoc[]

--- a/src/test/java/com/firstticket/bookingservice/support/RestDocsSupport.java
+++ b/src/test/java/com/firstticket/bookingservice/support/RestDocsSupport.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class RestDocsSupport {
@@ -18,7 +19,10 @@ public abstract class RestDocsSupport {
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-            .apply(documentationConfiguration(provider))
+            .apply(documentationConfiguration(provider)
+                .operationPreprocessors()
+                .withRequestDefaults(prettyPrint())
+                .withResponseDefaults(prettyPrint()))
             .build();
     }
 }


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->
- AsciiDoc 플러그인 설정 추가 및 RestDocs 연결 (`build.gradle`)
- 좌석 API AsciiDoc 문서 작성 (`index.adoc`)
- `RestDocsSupport` `prettyPrint` 설정 추가
- 자동 생성되는 `static/docs` `.gitignore` 추가


## 📌 관련 이슈
- close #42


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [x] refactor : 리팩토링
- [x] chore    : 빌드 설정, 의존성 업데이트 등
- [x] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
- `./gradlew build` 실행 후 앱을 실행해야 `/docs/index.html` 접근 가능
- `src/main/resources/static/docs`는 자동 생성 파일이라 `.gitignore`에 추가


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 전체 좌석 예약 API 문서 추가 및 정형화(목차, 요청/응답 예시, 에러 사례 포함).
  * 자동 생성된 문서 조각(snippets)을 통합해 가독성 높은 출력 생성.

* **Chores**
  * 문서 생성 및 배포 빌드 파이프라인 통합(테스트 산출물 연계 및 빌드 산출물에 문서 포함).
  * 버전관리 제외 규칙 업데이트로 생성문서 경로 제외 처리.

* **테스트**
  * 문서화용 테스트 출력의 가독성 향상(요청/응답 포맷팅 적용).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->