### PR TITLE
[refactor][booking-service] 좌석 내부 API 응답 구조 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -17,7 +17,8 @@
 
 === 응답 형식
 
-성공 / 실패 모두 `ApiResponse<T>` 형식으로 응답한다.
+외부 API는 성공 / 실패 모두 `ApiResponse<T>` 형식으로 응답한다.
+내부 API는 순수 DTO를 직접 반환한다.
 
 [source,json]
 ----
@@ -60,4 +61,4 @@ operation::seat-held-list-success[snippets='http-request,path-parameters,request
 
 == 회차별 잔여 좌석 수 조회 (내부 API)
 
-operation::seat-remaining-success[snippets='http-request,path-parameters,http-response,response-fields']
+operation::seat-internal-remaining-success[snippets='http-request,path-parameters,http-response,response-fields']

--- a/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatInternalController.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/presentation/SeatInternalController.java
@@ -1,11 +1,8 @@
 package com.firstticket.bookingservice.seat.presentation;
 
 import com.firstticket.bookingservice.seat.application.SeatQueryService;
-import com.firstticket.bookingservice.seat.application.dto.result.SeatRemainingResult;
 import com.firstticket.bookingservice.seat.presentation.dto.response.SeatRemainingResponse;
-import com.firstticket.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,12 +19,11 @@ public class SeatInternalController {
     private final SeatQueryService seatQueryService;
 
     @GetMapping("/remaining/{programId}")
-    public ResponseEntity<ApiResponse<List<SeatRemainingResponse>>> getRemainingCounts(
+    public List<SeatRemainingResponse> getRemainingCounts(
         @PathVariable UUID programId
     ) {
-        return ApiResponse.success(SeatSuccessCode.SEAT_REMAINING_OK,
-            seatQueryService.getRemainingCounts(programId).stream()
+        return seatQueryService.getRemainingCounts(programId).stream()
                 .map(SeatRemainingResponse::from)
-                .toList());
+                .toList();
     }
 }

--- a/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatInternalControllerTest.java
+++ b/src/test/java/com/firstticket/bookingservice/seat/presentation/SeatInternalControllerTest.java
@@ -51,19 +51,16 @@ class SeatInternalControllerTest extends RestDocsSupport {
         mockMvc.perform(RestDocumentationRequestBuilders
                 .get("/internal/v1/seats/remaining/{programId}", programId))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.code").value("SEAT_REMAINING_OK"))
-            .andDo(document("seat-remaining-success",
+            .andExpect(jsonPath("$[0].scheduleId").exists())
+            .andExpect(jsonPath("$[0].remainingCount").value(42))
+            .andExpect(jsonPath("$[1].remainingCount").value(10))
+            .andDo(document("seat-internal-remaining-success",
                 pathParameters(
                     parameterWithName("programId").description("프로그램 ID")
                 ),
                 responseFields(
-                    fieldWithPath("success").description("성공 여부"),
-                    fieldWithPath("code").description("응답 코드"),
-                    fieldWithPath("message").description("응답 메시지"),
-                    fieldWithPath("timestamp").description("응답 시간"),
-                    fieldWithPath("data[].scheduleId").description("회차 ID"),
-                    fieldWithPath("data[].remainingCount").description("잔여 좌석 수")
+                    fieldWithPath("[].scheduleId").description("회차 ID"),
+                    fieldWithPath("[].remainingCount").description("잔여 좌석 수")
                 )
             ));
     }


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

- 내부 API `/internal/v1/seats/remaining/{programId}` 응답에서 `ApiResponse` 래퍼 제거
- 순수 DTO(`List<SeatRemainingResponse>`) 직접 반환으로 변경
- 테스트코드 및 REST Docs 스니펫 식별자 수정


## 📌 관련 이슈
- close #47


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [x] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 내부 API와 외부 API의 응답 형식 차이점을 명시적으로 문서화했습니다.

* **리팩토링**
  * 내부 API 응답 구조를 단순화하여 DTO를 직접 반환하도록 변경했습니다.

* **테스트**
  * 업데이트된 응답 형식을 검증하도록 테스트를 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->