### PR TITLE
[feat][booking-service] 좌석 예매 취소 확정 이벤트 수신 구현

### DIFF
--- a/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/application/SeatCommandService.java
@@ -79,8 +79,19 @@ public class SeatCommandService {
         }
     }
 
+    @Transactional
     public void reserveSeats(List<UUID> seatIds, UUID scheduleId, UUID userId, String sessionId) {
         seatManager.reserveSeats(getSeats(seatIds, scheduleId), scheduleId, userId, sessionId);
+    }
+
+    @Transactional
+    public void restoreSeats(List<UUID> seatIds) {
+        List<SeatId> ids = toSeatIds(seatIds);
+        List<Seat> seats = seatRepository.findAllByIdIn(ids);
+        if (seats.size() != ids.size()) {
+            throw new SeatException(SeatErrorCode.SEAT_NOT_FOUND);
+        }
+        seats.forEach(Seat::restore);
     }
 
     private List<Seat> getSeats(List<UUID> seatIds, UUID scheduleId) {

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/Seat.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/Seat.java
@@ -149,4 +149,12 @@ public class Seat extends BaseEntity {
             case STANDING -> standingInfo.display(section.sectionName());
         };
     }
+
+    // 좌석 복구 RESERVED -> AVAILABLE
+    public void restore() {
+        if (this.status == SeatStatus.AVAILABLE) {
+            return; // 이미 복구된 상태면 무시
+        }
+        this.status = SeatStatus.AVAILABLE;
+    }
 }

--- a/src/main/java/com/firstticket/bookingservice/seat/domain/SeatRepository.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/domain/SeatRepository.java
@@ -22,4 +22,6 @@ public interface SeatRepository {
     Set<SeatId> findHeldSeatIds(List<SeatId> seatIds);
 
     List<SeatRemainingCount> countAvailableByProgramId(UUID programId);
+
+    List<Seat> findAllByIdIn(List<SeatId> ids);
 }

--- a/src/main/java/com/firstticket/bookingservice/seat/infrastructure/messaging/SeatKafkaConsumer.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/infrastructure/messaging/SeatKafkaConsumer.java
@@ -1,6 +1,7 @@
 package com.firstticket.bookingservice.seat.infrastructure.messaging;
 
 import com.firstticket.bookingservice.seat.application.SeatCommandService;
+import com.firstticket.bookingservice.seat.infrastructure.messaging.payload.BookingCancelConfirmedPayload;
 import com.firstticket.bookingservice.seat.infrastructure.messaging.payload.ProgramCreatedPayload;
 import com.firstticket.common.json.JsonUtil;
 import com.firstticket.common.messaging.annotation.IdempotentConsumer;
@@ -25,6 +26,17 @@ public class SeatKafkaConsumer {
         log.info("[SeatKafkaConsumer] 메시지 수신. key={}, value={}", record.key(), payload.toString());
 
         seatCommandService.createSeats(payload.toCommand());
+
+        ack.acknowledge();
+    }
+
+    @KafkaListener(topics = "booking.cancel.confirmed")
+    @IdempotentConsumer
+    public void consumeBookingCancelConfirmed(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        BookingCancelConfirmedPayload payload = JsonUtil.fromJson(record.value(), BookingCancelConfirmedPayload.class);
+        log.info("[SeatKafkaConsumer] 메시지 수신. key={}, value={}", record.key(), payload.toString());
+
+        seatCommandService.restoreSeats(payload.seatList());
 
         ack.acknowledge();
     }

--- a/src/main/java/com/firstticket/bookingservice/seat/infrastructure/messaging/payload/BookingCancelConfirmedPayload.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/infrastructure/messaging/payload/BookingCancelConfirmedPayload.java
@@ -1,0 +1,8 @@
+package com.firstticket.bookingservice.seat.infrastructure.messaging.payload;
+
+import java.util.List;
+import java.util.UUID;
+
+public record BookingCancelConfirmedPayload(
+    List<UUID> seatList
+) {}

--- a/src/main/java/com/firstticket/bookingservice/seat/infrastructure/persistence/SeatJpaRepository.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/infrastructure/persistence/SeatJpaRepository.java
@@ -27,4 +27,6 @@ public interface SeatJpaRepository extends JpaRepository<Seat, SeatId> {
             "GROUP BY s.scheduleId"
     )
     List<SeatRemainingCount> countAvailableByProgramId(@Param("programId") UUID programId);
+
+    List<Seat> findAllByIdIn(List<SeatId> seatIds);
 }

--- a/src/main/java/com/firstticket/bookingservice/seat/infrastructure/persistence/SeatRepositoryImpl.java
+++ b/src/main/java/com/firstticket/bookingservice/seat/infrastructure/persistence/SeatRepositoryImpl.java
@@ -150,4 +150,9 @@ public class SeatRepositoryImpl implements SeatRepository {
         return jpaRepository.countAvailableByProgramId(programId);
     }
 
+    @Override
+    public List<Seat> findAllByIdIn(List<SeatId> seatIds) {
+        return jpaRepository.findAllByIdIn(seatIds);
+    }
+
 }


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

- `booking.cancel.confirmed` Kafka 이벤트 수신 시 좌석 상태를 `RESERVED → AVAILABLE`로 복구하는 로직 구현


## 📌 관련 이슈
- close #67


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 예약 취소 시 좌석 자동 복구 기능 추가
  * 취소된 예약의 좌석이 즉시 사용 가능 상태로 변경되어 다른 고객이 예약할 수 있게 개선되었습니다
  * 예약 취소 이벤트에 대한 실시간 처리로 시스템의 좌석 가용성이 자동으로 업데이트됩니다

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/first-ticket/booking-service/pull/68)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->